### PR TITLE
Add 7 day cooldown to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,5 @@ updates:
       interval: "daily"
       time: "09:00"
     open-pull-requests-limit: 20
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Helps mitigate supply chain risk